### PR TITLE
Remove obsolete rspec1 code.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,19 +7,6 @@ def gemspec
   end
 end
 
-begin
-  require "spec"
-  require "spec/rake/spectask"
-rescue LoadError
-  raise 'Run `gem install rspec` to be able to run specs.'
-else
-  task :clear_tmp do
-    FileUtils.rm_rf(File.expand_path("../tmp", __FILE__))
-  end
-
-  Spec::Rake::SpecTask.new
-end
-
 desc "Build the gem"
 task :build => "#{gemspec.full_name}.gem"
 


### PR DESCRIPTION
It breaks the easy flow of typing "rake build; gem install ruby-vips-0.1.0.gem".
