### PR TITLE
Added Gemfile and fixed spec/ files to run on the latest RSpec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--drb

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+
+group :test do
+  gem 'rspec'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  specs:
+    diff-lcs (1.1.3)
+    rspec (2.10.0)
+      rspec-core (~> 2.10.0)
+      rspec-expectations (~> 2.10.0)
+      rspec-mocks (~> 2.10.0)
+    rspec-core (2.10.1)
+    rspec-expectations (2.10.0)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.10.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,13 @@
 $:.unshift File.expand_path('../../ext', __FILE__)
 
-require "rubygems"
 require "vips"
-require "spec"
+require "rspec"
 
 Dir["#{File.expand_path('../support', __FILE__)}/*.rb"].each do |file|
   require file
 end
 
-Spec::Runner.configure do |config|
+RSpec.configure do |config|
   config.include Spec::Path
   config.include Spec::Helpers
 
@@ -28,7 +27,7 @@ Spec::Runner.configure do |config|
   # end
 
 
-  # save this for RSpec2
+  #  save this for RSpec2
   #  config.filter_run_excluding :vips_lib_version => lambda{ |ver|
   #    return !Spec::Helpers.match_vips_version(ver)
   #  }

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,12 +1,12 @@
 require 'digest/sha1'
 
-Spec::Matchers.define :match_sha1 do |sha1|
+RSpec::Matchers.define :match_sha1 do |sha1|
   match do |image|
     Digest::SHA1.hexdigest(image.data) == sha1
   end
 end
 
-Spec::Matchers.define :match_image do |target|
+RSpec::Matchers.define :match_image do |target|
   match do |image|
     sha_ones = [image, target].map do |i|
       Digest::SHA1.hexdigest i.data
@@ -15,14 +15,14 @@ Spec::Matchers.define :match_image do |target|
   end
 end
 
-Spec::Matchers.define :approximate do |target|
+RSpec::Matchers.define :approximate do |target|
   match do |approximation|
     difference = (target - approximation).abs
     difference == 0 || (difference / approximation) < 0.01
   end
 end
 
-Spec::Matchers.define :be_in_array do |array|
+RSpec::Matchers.define :be_in_array do |array|
   match do |value|
     array.include?(value)
   end


### PR DESCRIPTION
It runs on latest RSpec2 2.10 now:

304 examples, 27 failures, 22 pending.

The half of failures there are because of some stuff wasn't included on my home Gentoo OS libvips portage version. 

I can ensure those are fixed later. Anyway the reason they fail is not related to RSpec migration!

Check it yourself:

``` bash
# in your ruby-vips
ruby ext/extconf.rb
make
cp vips_ext.so lib/
bundle exec rspec spec/
```
