### PR TITLE
Added Greg's fix to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-# Version 0.1.2-dev
+# master 
 
 ### Changed
 
 * Disable the vips8 operation cache to save some memory [John Cupitt]
+
+### Fixed
+
+* #8: Memory allocation-free issues [Grigoriy Chudnov]
 
 # Version 0.1.1
 


### PR DESCRIPTION
Also, sorry me for being pedantic, but I think 'master' on top CHANGELOG points more accurately to what's going on at present moment.

Having Version 0.1.2-dev while VIPS::VERSION is set '0.1.1' can somehow lead to confusion.

I am trying to follow the way Capybara guys do it, which I liked: https://github.com/jnicklas/capybara/blob/master/History.txt.

And... don't forget to enable issue tracker on your repo (jcupitt/ruby-vips). It is in Admin section there ;)
