### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ $ apt-get install libvips-dev
 ### OS X Prerequisites.
 
 ```bash
+$ brew tap homebrew/science
 $ brew install --use-llvm vips
 ```
 


### PR DESCRIPTION
Homebrew recently booted a bunch of formulas into their science repository, without telling anyone or providing deprecation warnings, and VIPS has been included in the move. 

<rant>
I opened up a ticket about this with Homebrew as the change has frustrated me a great deal and I think makes it (homebrew) substantially less easy to use. 
</rant>

Regardless, for the mean time, this is how to install VIPS via homebrew now.
