### PR TITLE
Remove ext/tags from gemspec files

### DIFF
--- a/ruby-vips.gemspec
+++ b/ruby-vips.gemspec
@@ -57,7 +57,6 @@ Gem::Specification.new do |s|
     "ext/reader.h",
     "ext/ruby_vips.c",
     "ext/ruby_vips.h",
-    "ext/tags",
     "ext/writer.c",
     "ext/writer.h",
     "lib/vips.rb",


### PR DESCRIPTION
Removed missing file from gemspec to fix issue https://github.com/jcupitt/ruby-vips/issues/56
