### PR TITLE
Add libvips dependency to gemspec which is respected by RubyInstaller…

### DIFF
--- a/ruby-vips.gemspec
+++ b/ruby-vips.gemspec
@@ -39,4 +39,6 @@ Gem::Specification.new do |spec|
   if Gem.ruby_version >= Gem::Version.new("2.2")
     spec.add_development_dependency "rubocop", ["~> 0.64"]
   end
+
+  spec.metadata["msys2_mingw_dependencies"] = "libvips"
 end


### PR DESCRIPTION
… on Windows

This automatically installs the mingw package "libvips" at gem install, so that ruby-vips can be used very easy.

The mechanism is described in:  https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#user-content-msys2-library-dependency