### PR TITLE
Fix Ruby 2.7 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
 
 script: bundle exec rake spec
 

--- a/lib/vips/image.rb
+++ b/lib/vips/image.rb
@@ -1174,7 +1174,7 @@ module Vips
         GObject::GValue.from_nick Vips::BLEND_MODE_TYPE, x
       end
 
-      Vips::Image.composite([self] + overlay, mode, opts)
+      Vips::Image.composite([self] + overlay, mode, **opts)
     end
 
     # Return the coordinates of the image maximum.
@@ -1424,7 +1424,7 @@ module Vips
     # @param opts [Hash] Set of options
     # @return [Vips::Image] Output image
     def scaleimage **opts
-      Vips::Image.scale self, opts
+      Vips::Image.scale self, **opts
     end
   end
 end

--- a/lib/vips/operation.rb
+++ b/lib/vips/operation.rb
@@ -77,13 +77,12 @@ module Vips
       @args.each do |details|
         arg_name = details[:arg_name]
         flags = details[:flags]
-        gtype = details[:gtype]
 
         if (flags & ARGUMENT_INPUT) != 0
           if (flags & ARGUMENT_REQUIRED) != 0 && 
              (flags & ARGUMENT_DEPRECATED) == 0
             @required_input << details
-          elsif 
+          else
             # we allow deprecated optional args
             @optional_input[arg_name] = details
           end


### PR DESCRIPTION
It's mostly about the keyword arguments semantic changes.