### PR TITLE
constructor is expecting strings not symbols

### DIFF
--- a/lib/vips/interpolate.rb
+++ b/lib/vips/interpolate.rb
@@ -14,18 +14,18 @@ module Vips
   #
   # But at least these should be available:
   #
-  # *   `:nearest` Nearest-neighbour interpolation.
-  # *   `:bilinear` Bilinear interpolation.
-  # *   `:bicubic` Bicubic interpolation.
-  # *   `:lbb` Reduced halo bicubic interpolation.
-  # *   `:nohalo` Edge sharpening resampler with halo reduction.
-  # *   `:vsqbs` B-Splines with antialiasing smoothing.
+  # *   `nearest` Nearest-neighbour interpolation.
+  # *   `bilinear` Bilinear interpolation.
+  # *   `bicubic` Bicubic interpolation.
+  # *   `lbb` Reduced halo bicubic interpolation.
+  # *   `nohalo` Edge sharpening resampler with halo reduction.
+  # *   `vsqbs` B-Splines with antialiasing smoothing.
   #
   #  For example:
   #
   #  ```ruby
   #  im = im.affine [2, 0, 0, 2],
-  #      :interpolate => Vips::Interpolate.new(:bicubic)
+  #      :interpolate => Vips::Interpolate.new('bicubic')
   #  ```
 
   class Interpolate < Vips::Object


### PR DESCRIPTION
```ruby
irb(main):001:0> require 'vips'
=> true
irb(main):002:0> Vips::Interpolate.new :bicubic
Traceback (most recent call last):
        7: from /home/noraj/.rbenv/versions/2.7.0/bin/irb:23:in `<main>'
        6: from /home/noraj/.rbenv/versions/2.7.0/bin/irb:23:in `load'
        5: from /home/noraj/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/irb-1.2.1/exe/irb:11:in `<top (required)>'
        4: from (irb):2
        3: from (irb):2:in `new'
        2: from /home/noraj/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/ruby-vips-2.0.17/lib/vips/interpolate.rb:51:in `initialize'
        1: from /home/noraj/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/ruby-vips-2.0.17/lib/vips/interpolate.rb:51:in `vips_interpolate_new'
TypeError (no implicit conversion of Symbol into String)
irb(main):003:0> Vips::Interpolate.new :bicubic.to_s
=> #<Vips::Interpolate:0x000055c0ff344598 @struct=#<Vips::Interpolate::ManagedStruct:0x000055c0ff344548>, @references=[]>
```