### PR TITLE
Adds new_from_memory method

### DIFF
--- a/lib/vips/gobject.rb
+++ b/lib/vips/gobject.rb
@@ -37,6 +37,8 @@ module GObject
     def_instance_delegators :@struct, :[], :to_ptr
     def_single_delegators :ffi_struct, :ptr
 
+    attr_reader :references
+
     # the layout of the GObject struct
     module GObjectLayout
       def self.included base

--- a/lib/vips/image.rb
+++ b/lib/vips/image.rb
@@ -324,19 +324,15 @@ module Vips
     # @return [Image] the loaded image
     def self.new_from_memory data, width, height, bands, format
       format_number = GObject::GValue.from_nick BAND_FORMAT_TYPE, format
-
-      pointer = create_data_pointer data
-
-      vi = Vips::vips_image_new_from_memory pointer, pointer.size, width, height, bands, format_number
-
+      size = data.respond_to?(:bytesize) ? data.bytesize : data.size
+      vi = Vips::vips_image_new_from_memory data, size, width, height, bands, format_number
       raise Vips::Error, "unable to make image from memory" if vi.null?
-
       image = new(vi)
 
       # keep a secret ref to the underlying object .. this reference will be
       # inherited by things that in turn depend on us, so the memory we are
       # using will not be freed
-      image.references << pointer
+      image.references << data
 
       image
     end
@@ -351,13 +347,9 @@ module Vips
     # @return [Image] the loaded image
     def self.new_from_memory_copy data, width, height, bands, format
       format_number = GObject::GValue.from_nick BAND_FORMAT_TYPE, format
-
-      pointer = create_data_pointer data
-
-      vi = Vips::vips_image_new_from_memory_copy pointer, pointer.size, width, height, bands, format_number
-
+      size = data.respond_to?(:bytesize) ? data.bytesize : data.size
+      vi = Vips::vips_image_new_from_memory_copy data, size, width, height, bands, format_number
       raise Vips::Error, "unable to make image from memory" if vi.null?
-
       new(vi)
     end
 

--- a/lib/vips/image.rb
+++ b/lib/vips/image.rb
@@ -1477,17 +1477,6 @@ module Vips
     def scaleimage **opts
       Vips::Image.scale self, **opts
     end
-
-    def self.create_data_pointer data
-      if data.is_a? FFI::Pointer
-        data
-      else
-        pointer = FFI::MemoryPointer.new :char, data.bytesize
-        pointer.write_bytes data
-        pointer
-      end
-    end
-    private_class_method :create_data_pointer
   end
 end
 

--- a/lib/vips/image.rb
+++ b/lib/vips/image.rb
@@ -323,15 +323,13 @@ module Vips
     # @param format [Symbol] band format
     # @return [Image] the loaded image
     def self.new_from_memory data, width, height, bands, format
-      format_number = GObject::GValue.from_nick BAND_FORMAT_TYPE, format
-
       # prevent data from being freed with JRuby FFI
       if defined?(JRUBY_VERSION) && !data.is_a?(FFI::Pointer)
         data = ::FFI::MemoryPointer.new(:char, data.bytesize).write_bytes data
       end
 
-      size = data.respond_to?(:bytesize) ? data.bytesize : data.size
-      vi = Vips::vips_image_new_from_memory data, size, width, height, bands, format_number
+      format_number = GObject::GValue.from_nick BAND_FORMAT_TYPE, format
+      vi = Vips::vips_image_new_from_memory data, data.bytesize, width, height, bands, format_number
       raise Vips::Error if vi.null?
       image = new(vi)
 
@@ -353,8 +351,7 @@ module Vips
     # @return [Image] the loaded image
     def self.new_from_memory_copy data, width, height, bands, format
       format_number = GObject::GValue.from_nick BAND_FORMAT_TYPE, format
-      size = data.respond_to?(:bytesize) ? data.bytesize : data.size
-      vi = Vips::vips_image_new_from_memory_copy data, size, width, height, bands, format_number
+      vi = Vips::vips_image_new_from_memory_copy data, data.bytesize, width, height, bands, format_number
       raise Vips::Error if vi.null?
       new(vi)
     end

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe Vips::Image do
     expect(x.avg).to eq(128)
   end
 
+  it 'can load an image from memory' do
+    image = Vips::Image.black(16, 16) + 128
+    data = image.write_to_memory
+
+    x = Vips::Image.new_from_memory data, image.width, image.height, image.bands, image.format
+
+    GC.start # make sure the memory isn't freed
+
+    expect(x.width).to eq(16)
+    expect(x.height).to eq(16)
+    expect(x.bands).to eq(1)
+    expect(x.avg).to eq(128)
+  end
+
   if has_jpeg?
     it 'can save an image to a buffer' do
       image = Vips::Image.black(16, 16) + 128

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -41,43 +41,11 @@ RSpec.describe Vips::Image do
     expect(x.avg).to eq(128)
   end
 
-  it 'can load an image from memory with pointer' do
-    image = Vips::Image.black(16, 16) + 128
-    data = image.write_to_memory
-
-    pointer = FFI::MemoryPointer.new(:char, data.bytesize)
-    pointer.write_bytes(data)
-
-    x = Vips::Image.new_from_memory pointer, image.width, image.height, image.bands, image.format
-
-    GC.start # make sure the memory isn't freed
-
-    expect(x.width).to eq(16)
-    expect(x.height).to eq(16)
-    expect(x.bands).to eq(1)
-    expect(x.avg).to eq(128)
-  end
-
   it 'can load an image from memory and copy' do
     image = Vips::Image.black(16, 16) + 128
     data = image.write_to_memory
 
     x = Vips::Image.new_from_memory_copy data, image.width, image.height, image.bands, image.format
-
-    expect(x.width).to eq(16)
-    expect(x.height).to eq(16)
-    expect(x.bands).to eq(1)
-    expect(x.avg).to eq(128)
-  end
-
-  it 'can load an image from memory and copy with pointer' do
-    image = Vips::Image.black(16, 16) + 128
-    data = image.write_to_memory
-
-    pointer = FFI::MemoryPointer.new(:char, data.bytesize)
-    pointer.write_bytes(data)
-
-    x = Vips::Image.new_from_memory_copy pointer, image.width, image.height, image.bands, image.format
 
     expect(x.width).to eq(16)
     expect(x.height).to eq(16)

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -41,6 +41,50 @@ RSpec.describe Vips::Image do
     expect(x.avg).to eq(128)
   end
 
+  it 'can load an image from memory with pointer' do
+    image = Vips::Image.black(16, 16) + 128
+    data = image.write_to_memory
+
+    pointer = FFI::MemoryPointer.new(:char, data.bytesize)
+    pointer.write_bytes(data)
+
+    x = Vips::Image.new_from_memory pointer, image.width, image.height, image.bands, image.format
+
+    GC.start # make sure the memory isn't freed
+
+    expect(x.width).to eq(16)
+    expect(x.height).to eq(16)
+    expect(x.bands).to eq(1)
+    expect(x.avg).to eq(128)
+  end
+
+  it 'can load an image from memory and copy' do
+    image = Vips::Image.black(16, 16) + 128
+    data = image.write_to_memory
+
+    x = Vips::Image.new_from_memory_copy data, image.width, image.height, image.bands, image.format
+
+    expect(x.width).to eq(16)
+    expect(x.height).to eq(16)
+    expect(x.bands).to eq(1)
+    expect(x.avg).to eq(128)
+  end
+
+  it 'can load an image from memory and copy with pointer' do
+    image = Vips::Image.black(16, 16) + 128
+    data = image.write_to_memory
+
+    pointer = FFI::MemoryPointer.new(:char, data.bytesize)
+    pointer.write_bytes(data)
+
+    x = Vips::Image.new_from_memory_copy pointer, image.width, image.height, image.bands, image.format
+
+    expect(x.width).to eq(16)
+    expect(x.height).to eq(16)
+    expect(x.bands).to eq(1)
+    expect(x.avg).to eq(128)
+  end
+
   if has_jpeg?
     it 'can save an image to a buffer' do
       image = Vips::Image.black(16, 16) + 128


### PR DESCRIPTION
Adds support for loading images from a binary string of pixel data. A few notes:

- Based on the [same function](https://github.com/libvips/pyvips/blob/b0a151af0e0c5d2a248009d148f4484b4344db6f/pyvips/vimage.py#L314) in pyvips
- Runs the GC in the test to confirm memory isn't freed (the test fails when the reference code is removed)
- Uses `send` to call a private function (could also have a public function named `_references` if that's preferred)

Also wanted to get your thoughts on having it accept a `FFI::Pointer` object, which would be useful for data that's already allocated (for performance).