### PR TITLE
Check for existance of homebrew on Mac and return lib path array

### DIFF
--- a/lib/vips.rb
+++ b/lib/vips.rb
@@ -5,10 +5,22 @@
 # License::   MIT
 
 require 'ffi'
+require 'open3'
 require 'logger'
 
 # This module uses FFI to make a simple layer over the glib and gobject
 # libraries.
+
+def mac_library_paths(library)
+  stdout, stderr, status = Open3.capture3('brew', '--prefix')
+  if status.success?
+    [library, "#{stdout.chomp}/lib/lib#{library}.dylib"]
+  else
+    library
+  end
+rescue Errno::ENOENT
+  library
+end
 
 # Generate a library name for ffi.
 #
@@ -27,7 +39,7 @@ def library_name(name, abi_number)
   if FFI::Platform.windows?
     "lib#{name}-#{abi_number}.dll"
   elsif FFI::Platform.mac?
-    "#{name}.#{abi_number}"
+    mac_library_paths("#{name}.#{abi_number}")
   else
     "#{name}.so.#{abi_number}"
   end


### PR DESCRIPTION
Not exactly sure why I ran into so many issues (couldn't find dylibs), but following the standard install instructions did not work for me. I can back fill more info later on, but wanted to start a PR in case it's helpful to others and/or I can figure out what I was missing.

----

This PR checks for the existence of homebrew on Mac platforms, then returns an array of libraries with the fallback being a full path to where homebrew would have placed a symlinked dylib. It continues to return the library name if the `brew` command is not found or returns a failure code.

I'm on macOS Catalina (10.15.7) with Ruby 2.6.6 installed using [asdf](https://github.com/asdf-vm/asdf) using homebrew installed to a custom directory (`~/homebrew`).

If this does end up being a solution that is needed for others I can add tests around the changes.
