### PR TITLE
Adds linter to make sure that code is consistent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,72 @@
+name: Test
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+
+env:
+  NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+  SPEC_OPTS: '--backtrace'
+
+jobs:
+  test:
+    name: Functional Testing
+    runs-on: ubuntu-20.04 # In order to install libvips 8.9+ version
+
+    strategy:
+      matrix:
+        ruby-version:
+          - 2.1
+          - 2.2
+          - 2.3
+          - 2.4
+          - 2.5
+          - 2.6
+          - 2.7
+          - jruby
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - name: Updates apt
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: sudo apt-get update -qq -o Acquire::Retries=3
+
+      - name: Install libvips
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run:
+          sudo apt install --fix-missing -qq --no-install-recommends -o Acquire::Retries=3
+            libvips libvips-dev libvips-tools
+            gettext
+            libcfitsio-dev
+            libexpat1-dev
+            libfftw3-dev
+            libgif-dev
+            libglib2.0-dev
+            libgsf-1-dev
+            libjpeg-turbo8-dev
+            liblcms2-dev
+            libmagickwand-dev
+            libmatio-dev
+            libopenexr-dev
+            libopenslide-dev
+            liborc-0.4-dev
+            libpango1.0-dev
+            libpoppler-glib-dev
+            libtiff5-dev
+            libwebp-dev
+            librsvg2-dev
+            libmagick++-dev
+
+      - name: Run Tests
+        run: bundle exec rake spec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,23 @@ env:
   SPEC_OPTS: '--backtrace'
 
 jobs:
+  name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+          bundler-cache: true
+
+      - name: Run Standard Ruby linter
+        run: bin/standardrb --no-fix --fail-fast
+        continue-on-error: true
+
   test:
     name: Functional Testing
     runs-on: ubuntu-20.04 # In order to install libvips 8.9+ version

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,8 @@
+fix: false              # default: false
+parallel: true          # default: false
+format: progress        # default: Standard::Formatter
+ruby_version: 2.5       # default: RUBY_VERSION
+default_ignores: false  # default: true
+
+ignore:                 # default: []
+  - 'vendor/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem 'github-markup'
 gem 'redcarpet', platforms: :ruby
+gem 'standard', platforms: :ruby

--- a/TODO
+++ b/TODO
@@ -9,7 +9,7 @@
 
 - Lint.
 
-	bundle exec rake rubocop
+	bundle exec standardrb
 
 - Reinstall local copy of gem after a change.
 
@@ -30,10 +30,6 @@
 	ruby > methods.rb
 	require 'vips'; Vips::Yard.generate
 	^D
-
-- Regenerate `.rubocop_todo.yml`.
-
-	bundle exec rubocop --auto-gen-config
 
 - Regenerate docs.
 


### PR DESCRIPTION
Added simple linter without configurations https://github.com/testdouble/standard which will help to support default ruby style guides with less time to support. But this will require to run to fix code for the whole repository and drop usage of the custom rubocop settings, but for simplicity to support this is worthy