### PR TITLE
Fix FFI::Pointer handling in Image#new_from_memory and Image#new_from_memory_copy

### DIFF
--- a/lib/vips/image.rb
+++ b/lib/vips/image.rb
@@ -326,6 +326,24 @@ module Vips
     #   image.width, image.height, image.bands, image.format
     # ```
     #
+    # Creating a new image from a memory pointer:
+    #
+    # ```
+    # ptr = FFI::MemoryPointer.new(:uchar, 10*10)
+    # # => #<FFI::MemoryPointer address=0x00007fc236db31d0 size=100>
+    # x = Vips::Image.new_from_memory(ptr, 10, 10, 1, :uchar)
+    # ```
+    #
+    # Creating a new image from an address only pointer:
+    #
+    # ```
+    # ptr = call_to_external_c_library(w: 10, h: 10)
+    # # => #<FFI::Pointer address=0x00007f9780813a00>
+    # ptr_slice = ptr.slice(0, 10*10)
+    # # => #<FFI::Pointer address=0x00007f9780813a00 size=100>
+    # x = Vips::Image.new_from_memory(ptr_slice, 10, 10, 1, :uchar)
+    # ```
+    #
     # {new_from_memory} keeps a reference to the array of pixels you pass in
     # to try to prevent that memory from being freed by the Ruby GC while it
     # is being used.
@@ -340,11 +358,19 @@ module Vips
     # @param format [Symbol] band format
     # @return [Image] the loaded image
     def self.new_from_memory data, width, height, bands, format
-      size = data.bytesize
-
       # prevent data from being freed with JRuby FFI
       if defined?(JRUBY_VERSION) && !data.is_a?(FFI::Pointer)
         data = ::FFI::MemoryPointer.new(:char, data.bytesize).write_bytes data
+      end
+
+      if data.is_a?(FFI::Pointer)
+        # A pointer needs to know about the size of the memory it points to.
+        # If you have an address-only pointer, use the .slice method to wrap
+        # the pointer in a size aware pointer.
+        raise Vips::Error, "pointer has no size limit" unless data.size_limit?
+        size = data.size
+      else
+        size = data.bytesize
       end
 
       format_number = GObject::GValue.from_nick BAND_FORMAT_TYPE, format
@@ -373,7 +399,15 @@ module Vips
     # @return [Image] the loaded image
     def self.new_from_memory_copy data, width, height, bands, format
       format_number = GObject::GValue.from_nick BAND_FORMAT_TYPE, format
-      vi = Vips.vips_image_new_from_memory_copy data, data.bytesize,
+
+      if data.is_a?(FFI::Pointer)
+        raise Vips::Error, "pointer has no size limit" unless data.size_limit?
+        size = data.size
+      else
+        size = data.bytesize
+      end
+
+      vi = Vips.vips_image_new_from_memory_copy data, size,
         width, height, bands, format_number
       raise Vips::Error if vi.null?
       new(vi)

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe Vips::Image do
     memory.put_array_of_uchar(0, Array.new(16 * 16, 128))
 
     data = FFI::Pointer.new(memory)
+    # JRuby's FFI implementation looses the size information
+    data = data.slice(0, 16 * 16) if defined?(JRUBY_VERSION)
 
     x = Vips::Image.new_from_memory data, 16, 16, 1, :uchar
 
@@ -113,6 +115,9 @@ RSpec.describe Vips::Image do
     memory.put_array_of_uchar(0, Array.new(16 * 16, 128))
 
     data = FFI::Pointer.new(memory)
+    # JRuby's FFI implementation looses the size information
+    data = data.slice(0, 16 * 16) if defined?(JRUBY_VERSION)
+
     x = Vips::Image.new_from_memory_copy data, 16, 16, 1, :uchar
 
     expect(x.width).to eq(16)

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe Vips::Image do
   end
 
   it "can load an image from memory by memory pointer" do
-    data = FFI::MemoryPointer.new(:uchar, 16*16)
-    data.put_array_of_uchar(0, Array.new(16*16, 128))
+    data = FFI::MemoryPointer.new(:uchar, 16 * 16)
+    data.put_array_of_uchar(0, Array.new(16 * 16, 128))
 
     x = Vips::Image.new_from_memory data, 16, 16, 1, :uchar
 
@@ -61,8 +61,8 @@ RSpec.describe Vips::Image do
   end
 
   it "can load an image from memory by size aware address pointer" do
-    memory = FFI::MemoryPointer.new(:uchar, 16*16)
-    memory.put_array_of_uchar(0, Array.new(16*16, 128))
+    memory = FFI::MemoryPointer.new(:uchar, 16 * 16)
+    memory.put_array_of_uchar(0, Array.new(16 * 16, 128))
 
     data = FFI::Pointer.new(memory)
 
@@ -97,8 +97,8 @@ RSpec.describe Vips::Image do
   end
 
   it "can load and copy an image from memory by memory pointer" do
-    data = FFI::MemoryPointer.new(:uchar, 16*16)
-    data.put_array_of_uchar(0, Array.new(16*16, 128))
+    data = FFI::MemoryPointer.new(:uchar, 16 * 16)
+    data.put_array_of_uchar(0, Array.new(16 * 16, 128))
 
     x = Vips::Image.new_from_memory_copy data, 16, 16, 1, :uchar
 
@@ -109,8 +109,8 @@ RSpec.describe Vips::Image do
   end
 
   it "can load and copy an image from memory by size aware address pointer" do
-    memory = FFI::MemoryPointer.new(:uchar, 16*16)
-    memory.put_array_of_uchar(0, Array.new(16*16, 128))
+    memory = FFI::MemoryPointer.new(:uchar, 16 * 16)
+    memory.put_array_of_uchar(0, Array.new(16 * 16, 128))
 
     data = FFI::Pointer.new(memory)
     x = Vips::Image.new_from_memory_copy data, 16, 16, 1, :uchar


### PR DESCRIPTION
- Allow `FFI::Pointer` to be passed as data argument to `Image#new_from_memory` and `Image#new_from_memory_copy`. 
- Requires the `FFI::Pointer` to have a valid size.
- Calculates the size using `.size` on `FFI::Pointer`, falls back to `.bytesize` for strings.

See bug report: https://github.com/libvips/ruby-vips/issues/295