### PR TITLE
fix: GType wrong size on windows

### DIFF
--- a/example/inheritance_with_refcount.rb
+++ b/example/inheritance_with_refcount.rb
@@ -132,8 +132,12 @@ module GLib
     end
   end
 
-  # :gtype will usually be 64-bit, but will be 32-bit on 32-bit Windows
-  typedef :ulong, :GType
+  # we can't just use ulong, windows has different int sizing rules
+  if FFI::Platform::ADDRESS_SIZE == 64
+    typedef :uint64, :GType
+  else
+    typedef :uint32, :GType
+  end
 end
 
 module Vips
@@ -144,7 +148,11 @@ module Vips
   GLib.set_log_domain(LOG_DOMAIN)
 
   # need to repeat this
-  typedef :ulong, :GType
+  if FFI::Platform::ADDRESS_SIZE == 64
+    typedef :uint64, :GType
+  else
+    typedef :uint32, :GType
+  end
 
   attach_function :vips_init, [:string], :int
   attach_function :vips_shutdown, [], :void

--- a/lib/vips.rb
+++ b/lib/vips.rb
@@ -575,7 +575,12 @@ module Vips
   LOG_DOMAIN = "VIPS"
   GLib.set_log_domain LOG_DOMAIN
 
-  typedef :ulong, :GType
+  # we can't just use ulong, windows has different int sizing rules
+  if FFI::Platform::ADDRESS_SIZE == 64
+    typedef :uint64, :GType
+  else
+    typedef :uint32, :GType
+  end
 
   attach_function :vips_error_buffer, [], :string
   attach_function :vips_error_clear, [], :void


### PR DESCRIPTION
On Windows 64-bit, using 64-bit ruby and 64-bit libvips, I was getting an error that a value for GType was too big for ulong. So I replaced all the instances of `typedef :ulong, :Gtype` with the FFI address check to make sure it is a `uint64` on windows 64-bit