### PR TITLE
Expose runtime settings & stats for metrics scraping and diagnostics

### DIFF
--- a/lib/vips.rb
+++ b/lib/vips.rb
@@ -625,6 +625,7 @@ module Vips
 
   attach_function :vips_leak_set, [:int], :void
   attach_function :vips_vector_set_enabled, [:int], :void
+  attach_function :vips_vector_isenabled, [], :int
   attach_function :vips_concurrency_set, [:int], :void
 
   # vips_foreign_get_suffixes was added in libvips 8.8
@@ -640,20 +641,66 @@ module Vips
     vips_leak_set((leak ? 1 : 0))
   end
 
+  attach_function :vips_tracked_get_mem, [], :int
+  attach_function :vips_tracked_get_mem_highwater, [], :int
+  attach_function :vips_tracked_get_allocs, [], :int
+  attach_function :vips_tracked_get_files, [], :int
+  attach_function :vips_cache_get_max, [], :int
+  attach_function :vips_cache_get_max_mem, [], :int
+  attach_function :vips_cache_get_max_files, [], :int
   attach_function :vips_cache_set_max, [:int], :void
   attach_function :vips_cache_set_max_mem, [:int], :void
   attach_function :vips_cache_set_max_files, [:int], :void
+  attach_function :vips_cache_print, [], :void
+  attach_function :vips_cache_drop_all, [], :void
+
+  # Get the number of bytes currently allocated via vips_malloc.
+  def self.tracked_mem
+    vips_tracked_get_mem
+  end
+
+  # Get the greatest number of bytes ever actively allocated via vips_malloc.
+  def self.tracked_mem_highwater
+    vips_tracked_get_mem_highwater
+  end
+
+  # Get the number of active allocations.
+  def self.tracked_allocs
+    vips_tracked_get_allocs
+  end
+
+  # Get the number of open files.
+  def self.tracked_files
+    vips_tracked_get_files
+  end
+
+  # Get the maximum number of operations that libvips should cache.
+  def self.cache_max
+    vips_cache_get_max
+  end
+
+  # Get the maximum amount of memory that libvips uses for the operation cache.
+  def self.cache_max_mem
+    vips_cache_get_max_mem
+  end
+
+  # Get the maximum number of files libvips keeps open in the operation cache.
+  def self.cache_max_files
+    vips_cache_get_max_files
+  end
 
   # Set the maximum number of operations that libvips should cache. Set 0 to
   # disable the operation cache. The default is 1000.
   def self.cache_set_max size
     vips_cache_set_max size
+    cache_max
   end
 
   # Set the maximum amount of memory that libvips should use for the operation
   # cache. Set 0 to disable the operation cache. The default is 100mb.
   def self.cache_set_max_mem size
     vips_cache_set_max_mem size
+    cache_max_mem
   end
 
   # Set the maximum number of files libvips should keep open in the
@@ -661,6 +708,17 @@ module Vips
   # 100.
   def self.cache_set_max_files size
     vips_cache_set_max_files size
+    cache_max_files
+  end
+
+  # Print the libvips operation cache to stdout. Handy for debugging.
+  def self.cache_print # :nodoc:
+    vips_cache_print
+  end
+
+  # Drop the libvips operation cache. Handy for leak tracking.
+  def self.cache_drop_all # :nodoc:
+    vips_cache_drop_all
   end
 
   # Set the size of the libvips worker pool. This defaults to the number of
@@ -669,11 +727,19 @@ module Vips
     vips_concurrency_set n
   end
 
+  # Whether SIMD and the run-time compiler are enabled. This can give a nice
+  # speed-up, but can also be unstable on some systems or with some versions
+  # of the run-time compiler.
+  def self.vector?
+    vips_vector_isenabled == 1
+  end
+
   # Enable or disable SIMD and the run-time compiler. This can give a nice
   # speed-up, but can also be unstable on some systems or with some versions
   # of the run-time compiler.
   def self.vector_set enabled
     vips_vector_set_enabled(enabled ? 1 : 0)
+    vector?
   end
 
   # Deprecated compatibility function.

--- a/spec/vips_spec.rb
+++ b/spec/vips_spec.rb
@@ -6,8 +6,16 @@ RSpec.describe Vips do
       Vips.concurrency_set 12
     end
 
-    it "can set SIMD" do
-      Vips.vector_set true
+    it "sets SIMD" do
+      default = Vips.vector?
+
+      expect(Vips.vector_set(true)).to be true
+      expect(Vips.vector?).to be true
+
+      expect(Vips.vector_set(false)).to be false
+      expect(Vips.vector?).to be false
+
+      Vips.vector_set default
     end
 
     it "can enable leak testing" do
@@ -15,24 +23,59 @@ RSpec.describe Vips do
       Vips.leak_set false
     end
 
-    it "can set the operation cache size" do
-      Vips.cache_set_max 0
-      Vips.cache_set_max 100
-    end
-
-    it "can set the operation cache memory limit" do
-      Vips.cache_set_max_mem 0
-      Vips.cache_set_max_mem 10000000
-    end
-
-    it "can set the operation cache file limit" do
-      Vips.cache_set_max_files 0
-      Vips.cache_set_max_files 100
-    end
-
     it "can get a set of filename suffixes" do
       suffs = Vips.get_suffixes
       expect(suffs.length > 10).to be true unless suffs.empty?
+    end
+  end
+
+  describe "cache" do
+    it "can get and set the operation cache size" do
+      default = Vips.cache_max
+
+      expect(Vips.cache_set_max(0)).to be 0
+      expect(Vips.cache_max).to be 0
+
+      expect(Vips.cache_set_max(default)).to be default
+      expect(Vips.cache_max).to be default
+    end
+
+    it "can set the operation cache memory limit" do
+      default = Vips.cache_max_mem
+
+      expect(Vips.cache_set_max_mem(0)).to be 0
+      expect(Vips.cache_max_mem).to be 0
+
+      expect(Vips.cache_set_max_mem(default)).to be default
+      expect(Vips.cache_max_mem).to be default
+    end
+
+    it "can set the operation cache file limit" do
+      default = Vips.cache_max_files
+
+      expect(Vips.cache_set_max_files(0)).to be 0
+      expect(Vips.cache_max_files).to be 0
+
+      expect(Vips.cache_set_max_files(default)).to be default
+      expect(Vips.cache_max_files).to be default
+    end
+  end
+
+  describe "#tracked_*" do
+    it "can get allocated bytes" do
+      expect(Vips.tracked_mem).to be >= 0
+    end
+
+    it "can get allocated bytes high-water mark" do
+      expect(Vips.tracked_mem_highwater).to be >= 0
+    end
+
+    it "can get allocation count" do
+      expect(Vips.tracked_allocs).to be >= 0
+    end
+
+    it "can get open file count" do
+      expect(Vips.tracked_files).to be >= 0
     end
   end
 


### PR DESCRIPTION
I frequently find myself attaching these via FFI for closer inspection, so I figured they may be worthwhile to have available by default.

Metrics for allocations and open files:
* `Vips.tracked_mem` - bytes currently allocated
* `Vips.tracked_mem_highwater` - max bytes allocated
* `Vips.tracked_allocs` - current allocation count
* `Vips.tracked_files` - current open file count

Expose global settings for inspection:
* `Vips.vector?` - whether SIMD vector support is enabled
* `Vips.cache_max` - max operations to cache
* `Vips.cache_max_mem` - max bytes to cache
* `Vips.cache_max_files` - max open files to cache

Updated the corresponding Ruby setter methods to return the new value rather than `nil`.