### PR TITLE
Add Ruby 3.2 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,9 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - '3.0'
           - 3.1
+          - 3.2
           - jruby
       fail-fast: true
 
@@ -55,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Quote '3.0' so it properly loads a Ruby 3.0.x version.  Otherwise the 3.0 is truncated to 3, and Ruby 3.2.x is loaded.

Update the checkout action version.

Runs green on my fork.