### PR TITLE
Allow to use vips_block_untrusted_set and vips_operation_block_set methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* add `Vips.block_untrusted` method to block all untrusted operations. Only for libvips >= 8.13. [Docs](https://www.libvips.org/API/current/libvips-vips.html#vips-block-untrusted-set). [#382](https://github.com/libvips/ruby-vips/pull/382) [aglushkov](https://github.com/aglushkov)
+* add `Vips.block` method to block specific operation. Only for libvips >= 8.13. [Docs](https://www.libvips.org/API/current/VipsOperation.html#vips-operation-block-set). [#382](https://github.com/libvips/ruby-vips/pull/382) [aglushkov](https://github.com/aglushkov)
 * `new_from_source` keeps a ref to the source object [taylorthurlow]
 * some fixes to object references system
 

--- a/lib/vips.rb
+++ b/lib/vips.rb
@@ -779,6 +779,31 @@ module Vips
     major > x || (major == x && minor >= y)
   end
 
+  if at_least_libvips?(8, 13)
+    attach_function :vips_block_untrusted_set, [:bool], :void
+    attach_function :vips_operation_block_set, %i[string bool], :void
+
+    # Block/unblock all untrusted operations from running.
+    # Use `vips -l` at the command-line to see the class hierarchy and which operations are marked as untrusted.
+    def self.block_untrusted(enabled)
+      vips_block_untrusted_set(enabled)
+    end
+
+    # Block/unblock all operations in the libvips class hierarchy at specified *operation_name* and below.
+    #
+    # For example this will block all loaders except JPEG
+    #
+    #   Vips.block("VipsForeignLoad", true);
+    #   Vips.block("VipsForeignLoadJpeg", false)
+    #
+    # Use `vips -l` at the command-line to see the class hierarchy.
+    # This call does nothing if the named operation is not found.
+    #
+    def self.block(operation_name, enabled)
+      vips_operation_block_set(operation_name, enabled)
+    end
+  end
+
   # Get a list of all supported file suffixes.
   #
   # @return [[String]] array of supported suffixes

--- a/spec/block_operations_spec.rb
+++ b/spec/block_operations_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+RSpec.describe Vips, version: [8, 13] do
+  let(:svg_image) { simg("lion.svg") }
+  let(:jpg_image) { simg("wagon.jpg") }
+
+  if has_svg?
+    it "can block untrusted operations" do
+      untrusted_image = svg_image # svgload operation is known as untrusted
+
+      # Block
+      Vips.block_untrusted(true)
+      expect { Vips::Image.new_from_file(untrusted_image) }.to raise_error Vips::Error, /svgload/
+
+      # Unblock
+      Vips.block_untrusted(false)
+      expect { Vips::Image.new_from_file(untrusted_image) }.not_to raise_error
+    end
+  end
+
+  if has_jpeg? && has_svg?
+    it "can block specific operations" do
+      # Block all loaders except jpeg
+      Vips.block("VipsForeignLoad", true)
+      Vips.block("VipsForeignLoadJpeg", false)
+      expect { Vips::Image.new_from_file(svg_image) }.to raise_error Vips::Error, /svgload/
+      expect { Vips::Image.new_from_file(jpg_image) }.not_to raise_error
+
+      # Unblock all loaders
+      Vips.block("VipsForeignLoad", false)
+      expect { Vips::Image.new_from_file(svg_image) }.not_to raise_error
+    end
+  end
+end

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -1,9 +1,5 @@
 require "spec_helper"
 
-def has_jpeg?
-  Vips.type_find("VipsOperation", "jpegload") != nil
-end
-
 RSpec.describe Vips::Image do
   it "can save an image to a file" do
     filename = timg "x.v"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,14 @@ def timg(name)
   File.join(@temp_dir, name)
 end
 
+def has_jpeg?
+  Vips.type_find("VipsOperation", "jpegload") != nil
+end
+
+def has_svg?
+  Vips.type_find("VipsOperation", "svgload") != nil
+end
+
 RSpec.configure do |config|
   config.around do |example|
     Dir.mktmpdir("ruby-vips-spec-") do |dir|


### PR DESCRIPTION
Some forgotten stuff I think... 

I wrote tests  same way as they are in python library 
https://github.com/libvips/pyvips/blob/a9688b9c7c2a4b448eec0f0a9375c8f34e76354e/tests/test_block.py#L38