### PR TITLE
Fix a method redefinition warning

### DIFF
--- a/lib/vips/object.rb
+++ b/lib/vips/object.rb
@@ -9,9 +9,6 @@ require "ffi"
 module Vips
   private
 
-  # debugging support
-  attach_function :vips_object_print_all, [], :void
-
   # we must init these by hand, since they are usually made on first image
   # create
   attach_function :vips_band_format_get_type, [], :GType
@@ -337,6 +334,7 @@ module Vips
       ArgumentClassPtr.ptr, ArgumentInstancePtr.ptr],
     :int
 
+  # debugging support
   attach_function :vips_object_print_all, [], :void
 
   attach_function :vips_object_set_from_string, [:pointer, :string], :int


### PR DESCRIPTION
```
$ bundle exec rspec -w
/home/user/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ffi-1.16.3/lib/ffi/function.rb:65: warning: method redefined; discarding old vips_object_print_all
/home/user/rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ffi-1.16.3/lib/ffi/function.rb:65: warning: method redefined; discarding old vips_object_print_all
.....................................................................................................................

Finished in 0.46228 seconds (files took 0.1336 seconds to load)
117 examples, 0 failures
```

This warning also appears when running tests in projects that make use of ruby-vips.

Simply remove the first definition. Note: `attach_function` does not respect visibility modifiers. The methods in the private section are in fact public. So there is no behaviour change here.