### PR TITLE
Lint code

### DIFF
--- a/lib/vips/operation.rb
+++ b/lib/vips/operation.rb
@@ -218,7 +218,7 @@ module Vips
         raise Vips::Error if value.null?
       end
 
-      super(value)
+      super
     end
 
     def build


### PR DESCRIPTION
Hi,

I saw that the linting Actions job was failing and decided to correct it to pass.

From `standardrb`:

> Style/SuperArguments: Call super without arguments and parentheses when the signature is identical

Please let me know if you have any questions for me.