### PR TITLE
Ensure variadic call is null-terminated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* fix `Image#add_alpha()` with libvips 8.16 [kleisauke]
+
 ## Version 2.2.2 (2024-07-17)
 
 * fix compat with unified (semistatic) libvips binaries [kleisauke]

--- a/lib/vips/image.rb
+++ b/lib/vips/image.rb
@@ -973,7 +973,7 @@ module Vips
       # @return [Image] new image
       def add_alpha
         ptr = GenericPtr.new
-        result = Vips.vips_addalpha self, ptr
+        result = Vips.vips_addalpha self, ptr, :pointer, nil
         raise Vips::Error if result != 0
 
         Vips::Image.new ptr[:value]


### PR DESCRIPTION
Noticed on https://qa.debian.org/excuses.php?package=vips.