### PR TITLE
Ensure correct FFI function definitions for `gboolean` parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * fix `Image#add_alpha()` with libvips 8.16 [kleisauke]
+* fix FFI function definitions for `gboolean` parameters [kleisauke]
 
 ## Version 2.2.2 (2024-07-17)
 

--- a/lib/vips.rb
+++ b/lib/vips.rb
@@ -810,13 +810,13 @@ module Vips
   end
 
   if at_least_libvips?(8, 13)
-    attach_function :vips_block_untrusted_set, [:bool], :void
-    attach_function :vips_operation_block_set, %i[string bool], :void
+    attach_function :vips_block_untrusted_set, [:int], :void
+    attach_function :vips_operation_block_set, [:string, :int], :void
 
     # Block/unblock all untrusted operations from running.
     # Use `vips -l` at the command-line to see the class hierarchy and which operations are marked as untrusted.
-    def self.block_untrusted(enabled)
-      vips_block_untrusted_set(enabled)
+    def self.block_untrusted(state)
+      vips_block_untrusted_set(state ? 1 : 0)
     end
 
     # Block/unblock all operations in the libvips class hierarchy at specified *operation_name* and below.
@@ -829,8 +829,8 @@ module Vips
     # Use `vips -l` at the command-line to see the class hierarchy.
     # This call does nothing if the named operation is not found.
     #
-    def self.block(operation_name, enabled)
-      vips_operation_block_set(operation_name, enabled)
+    def self.block(operation_name, state)
+      vips_operation_block_set(operation_name, state ? 1 : 0)
     end
   end
 

--- a/lib/vips/image.rb
+++ b/lib/vips/image.rb
@@ -14,8 +14,8 @@ module Vips
 
   attach_function :vips_image_copy_memory, [:pointer], :pointer
 
-  attach_function :vips_image_set_progress, [:pointer, :bool], :void
-  attach_function :vips_image_set_kill, [:pointer, :bool], :void
+  attach_function :vips_image_set_progress, [:pointer, :int], :void
+  attach_function :vips_image_set_kill, [:pointer, :int], :void
 
   attach_function :vips_filename_get_filename, [:string], :pointer
   attach_function :vips_filename_get_options, [:string], :pointer
@@ -716,7 +716,7 @@ module Vips
     # @see Object#signal_connect
     # @param state [Boolean] progress signalling state
     def set_progress state
-      Vips.vips_image_set_progress self, state
+      Vips.vips_image_set_progress(self, state ? 1 : 0)
     end
 
     # Kill computation of this time.
@@ -727,7 +727,7 @@ module Vips
     # @see Object#signal_connect
     # @param kill [Boolean] stop computation
     def set_kill kill
-      Vips.vips_image_set_kill self, kill
+      Vips.vips_image_set_kill(self, kill ? 1 : 0)
     end
 
     # Get the `GType` of a metadata field. The result is 0 if no such field


### PR DESCRIPTION
`gboolean` is a typedef for `int` in GLib.

Resolves: #410.