### PR TITLE
fix: exclude `.github` directory from published gem

### DIFF
--- a/ruby-vips.gemspec
+++ b/ruby-vips.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = %w[LICENSE.txt README.md TODO]
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r{^(test|spec|features|\.github)/})
   end
 
   spec.required_ruby_version = ">= 2.0.0"


### PR DESCRIPTION
This reduces the gem size by a huge 24K 😅 